### PR TITLE
fix(api): bcrypt dependency included

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv
 sqlalchemy
 pydantic
 pydantic[email]
-passlib[bcrpyt]
+passlib
+bcrypt
 python-jose
 pre-commit


### PR DESCRIPTION
### Fixes/Implements #3 

## Description

`requirements.txt` has been modified to include the `bcrypt` dependency, which as causing the problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
