### PR TITLE
feat(cdn): added albums, users pictures support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 .pytest_cache
 htmlcov
 dist
+cdn_assets
 site
 .coverage
 coverage.xml

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,8 @@
+import os
+
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
 from api.endpoints import user, artist, song, playlist, album, rating
 from core.utils.database import Base, engine
 from core.utils.middlewares import init_middlewares
@@ -13,6 +17,9 @@ app = FastAPI(
     redoc_url="/redocs",
     contact={"name": "Niyas Hameed", "url": "https://niyas-hameed.vercel.app/"},
 )
+
+os.makedirs(os.path.dirname(f"cdn_assets/"), exist_ok=True)
+app.mount("/cdn_asset/", StaticFiles(directory="cdn_assets"), name="static")
 
 init_middlewares(app)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ passlib
 bcrypt
 python-jose
 pre-commit
+python-multipart
+requests


### PR DESCRIPTION
### Fixes/Implements #15 

## Description

- Ensured `users`, `artists` and `albums` each have their own cover picture.
- The endpoint built accepts files, they're written into static files for access.
- The endpoints additionally accepts an URL for the pictures.
- There is another endpoint created in both `albums` and `users` for removing the display pictures.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested
