### PR TITLE
fix(playlist): integrated `Elasticsearch` with song additions, removal in playlist

### DIFF
--- a/backend/api/endpoints/album.py
+++ b/backend/api/endpoints/album.py
@@ -134,11 +134,13 @@ async def delete_album(album_id: str, db: Session = Depends(get_db)):
         raise not_found_error("album")
 
     del_query = {"query": {"term": {"album_id": find_album.id}}}
+    del_playlist_song_query = {"script": {"source": "ctx._source.songs.removeIf(song -> song.album_id == params.album_id)", "lang": "painless", "params": {"album_id": find_album.id}}}
 
     try:
         db.delete(find_album)
         db.commit()
 
+        es.update_by_query(index="playlists", body=del_playlist_song_query)
         es.delete_by_query(index="ratings", body=del_query)
         es.delete_by_query(index="songs", body=del_query)
         es.delete(index="albums", id=find_album.id)

--- a/backend/api/endpoints/artist.py
+++ b/backend/api/endpoints/artist.py
@@ -130,12 +130,14 @@ async def delete_artist(artist_id: str, db: Session = Depends(get_db)):
         raise not_found_error("artist")
 
     del_query = {"query": {"term": {"artist_id": find_artist.id}}}
+    del_playlist_song_query = {"script": {"source": "ctx._source.songs.removeIf(song -> song.artist_id == params.artist_id)", "lang": "painless", "params": {"artist_id": find_artist.id}}}
 
     try:
         db.delete(find_artist)
         db.commit()
 
         es.delete_by_query(index="ratings", body=del_query)
+        es.update_by_query(index="playlists", body=del_playlist_song_query)
         es.delete_by_query(index="songs", body=del_query)
         es.delete_by_query(index="albums", body=del_query)
         es.delete(index="artists", id=find_artist.id)

--- a/backend/core/utils/search.py
+++ b/backend/core/utils/search.py
@@ -69,6 +69,7 @@ def initialize_indexes():
                 "title": {"type": "text"},
                 "user_id": {"type": "keyword"},
                 "username": {"type": "text"},
+                "songs": {"type": "nested"}
             }
         }
     }


### PR DESCRIPTION
### Fixes/Implements #27 

## Description

The `ES` indexes are using song additions, removals to ensure that the user relevance to artists can be acquired.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
