### PR TITLE
feat(recommendation): tags-based recommendation system

### DIFF
--- a/backend/api/endpoints/artist.py
+++ b/backend/api/endpoints/artist.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends, status
 
+from urllib.parse import unquote
+
 from sqlalchemy.orm import Session
 from core.utils.search import es
 
@@ -73,6 +75,28 @@ async def get_artist(artist_id: str, db: Session = Depends(get_db)):
             "albums": find_artist.albums,
             "songs": find_artist.songs[0:5],
         },
+    }
+
+
+@router.get(
+    "/genre/{genre}",
+    status_code=status.HTTP_200_OK,
+)
+async def get_artists_by_genre(genre: str, db: Session = Depends(get_db)):
+    """
+    Returns the artists with the given genre.
+    """
+
+    decoded_genre = unquote(genre)
+
+    find_artists = db.query(Artist).filter(Artist.genre == decoded_genre).all()
+
+    if not find_artists:
+        raise not_found_error("artists")
+
+    return {
+        "message": "Artists Found!",
+        "data": find_artists,
     }
 
 

--- a/backend/api/endpoints/playlist.py
+++ b/backend/api/endpoints/playlist.py
@@ -215,6 +215,7 @@ async def add_song_to_playlist(
             "album_title": find_song.album.title,
             "genre": find_song.genre,
             "length": find_song.length,
+            "tags": find_song.tags,
         }
 
         es.update(

--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -86,13 +86,18 @@ async def recommendation(request: Request):
 
     user = request.state.user
 
+    like_documents = []
+
+    for artist_id in user.interests:
+        like_documents.append({"_index": "artists", "_id": artist_id})
+
     search_query = {
         "query": {
             "more_like_this": {
-                "fields": ["genre"],
-                "like": user.interests,
+                "fields": ["title", "tags"],
+                "like": like_documents,
                 "min_term_freq": 1,
-                "max_query_terms": 20,
+                "max_query_terms": 25,
             }
         },
     }
@@ -102,7 +107,7 @@ async def recommendation(request: Request):
         song_results = es.search(index=["songs"], body=search_query)
         song_hits = song_results.get("hits", {}).get("hits", [])
 
-        artist_results = es.search(index=["artists"], body=search_query)
+        artist_results = es.search(index=["artists"], body=search_query, size=2)
         artist_hits = artist_results.get("hits", {}).get("hits", [])
 
         return {

--- a/backend/core/utils/search.py
+++ b/backend/core/utils/search.py
@@ -19,7 +19,7 @@ def initialize_indexes():
                 "id": {"type": "keyword"},
                 "name": {"type": "text"},
                 "genre": {"type": "keyword"},
-                "user_id": {"type": "keyword"},
+                "tags": {"type": "keyword"},
             }
         }
     }
@@ -31,6 +31,7 @@ def initialize_indexes():
                 "title": {"type": "text"},
                 "artist_id": {"type": "keyword"},
                 "arist_name": {"type": "text"},
+                "tags": {"type": "keyword"},
             }
         }
     }
@@ -46,6 +47,7 @@ def initialize_indexes():
                 "album_title": {"type": "text"},
                 "genre": {"type": "keyword"},
                 "length": {"type": "integer"},
+                "tags": {"type": "keyword"},
             }
         }
     }

--- a/frontend/src/components/albumwrap/albumwrap.styles.ts
+++ b/frontend/src/components/albumwrap/albumwrap.styles.ts
@@ -4,7 +4,7 @@ export const AlbumWrapWrapper = styled.div`
     padding: 1.5rem;
     box-sizing: border-box;
 
-    min-width: 15rem;
+    width: 15rem;
 
     background-color: var(--secondary-background-color);
 
@@ -20,11 +20,16 @@ export const AlbumWrapWrapper = styled.div`
 
     &:hover {
         background-color: var(--tertiary-color);
+    }
 
+    @media only screen and (max-width: 500px) {
+        width: 100%;
     }
 `
 
 export const AlbumWrapImage = styled.img`
     object-fit: cover;
+    width: 100%;
+    height: 100%;
     border-radius: 1rem;
 `

--- a/frontend/src/containers/auth/artists.tsx
+++ b/frontend/src/containers/auth/artists.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { AuthContent, AuthHeader, AuthWrapper, AuthForm, AuthSubmit, AuthSpec, ArtistFormFields, ArtistField } from "./auth.styles";
+
+import logo_large from '../../assets/logo/rhythmb.svg';
+import axios from "axios";
+import { toast } from "react-toastify";
+
+interface ArtistsProps {
+    handleArtistsChange: (interests: string[]) => void,
+    genres: string[],
+    handleFormSubmit: () => void
+}
+
+interface ArtistType {
+    id: string,
+    genre: string,
+    name: string
+}
+
+export default function Artists({ handleArtistsChange, genres, handleFormSubmit }: ArtistsProps) {
+
+    const [artists, setArtists] = useState<string[]>([])
+    const [loading, setLoading] = useState<boolean>(false)
+
+    const [artistsDetails, setArtistsDetails] = useState<ArtistType[]>([])
+
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const requests = genres.map(async (genre) => {
+                    const response = await axios.get(import.meta.env.VITE_BASE_API + '/artist/genre/' + genre);
+                    return response.data.data || []
+                })
+
+                const artistsArrays = await Promise.all(requests)
+
+                const allArtists = [...new Set(artistsArrays.flat())]
+
+                setArtistsDetails(allArtists)
+            } catch (error) {
+                toast.error("Something went wrong!")
+            }
+        }
+
+        fetchData();
+    }, [genres]);
+
+    const handleAuthSubmit = async () => {
+        if (loading || artists.length < 2) {
+            return
+        }
+        setLoading(true)
+        await handleFormSubmit()
+        setLoading(false)
+    }
+
+    useEffect(() => {
+        handleArtistsChange(artists)
+    }, [artists])
+
+    return (
+        <AuthWrapper>
+            <AuthContent>
+                <AuthHeader
+                    src={logo_large}
+                    alt="RhythmB"
+                />
+                <AuthForm>
+                    <AuthSpec><span>Which Artist would you pick?</span>(Select Atleast 2)</AuthSpec>
+                    <ArtistFormFields>
+                    {
+                        artistsDetails.map((artistDetail: ArtistType) => (
+                            <ArtistField
+                                key={artistDetail.id}
+                                onClick={() => {
+                                    if (artists.includes(artistDetail.id)) {
+                                        setArtists(artists.filter((artist: string) => artist !== artistDetail.id))
+                                    }
+                                    else {
+                                        setArtists([...artists, artistDetail.id])
+                                    }
+                                }}
+                                $selected={artists.includes(artistDetail.id)}
+                            >
+                                {artistDetail.name.toUpperCase()}
+                            </ArtistField>
+                        ))
+                    }
+                    </ArtistFormFields>
+                    <AuthSubmit
+                        onClick={handleAuthSubmit}
+                        $loading={loading || artists.length < 2}
+                    >
+                        <h3>Sign Up</h3>
+                    </AuthSubmit>
+                </AuthForm>
+            </AuthContent>
+        </AuthWrapper>
+    )
+
+
+}

--- a/frontend/src/containers/auth/auth.styles.ts
+++ b/frontend/src/containers/auth/auth.styles.ts
@@ -213,3 +213,36 @@ export const GenreField = styled.p<{ $selected: boolean }>`
         border: 0.1rem solid white;
     }
 `
+
+export const ArtistFormFields = styled.div`
+    width: 100%;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+`
+
+export const ArtistField = styled.p<{ $selected: boolean }>`
+    height: auto;
+    padding: 1rem;
+    box-sizing: border-box;
+    text-align: justify;
+
+    border: 0.1rem solid var(--tertiary-color);
+    border-radius: var(--border-radius-large);
+    background-color: ${props => props.$selected ? "var(--tertiary-color)" : "transparent"};
+
+    transition: all 0.2s ease-in-out;
+
+    cursor: pointer;
+    color: var(--secondary-color);
+
+    span {
+        color: ${props => props.$selected ? "var(--secondary-font-color)" : "var(--primary-color)"};
+        font-weight: 400;
+    }
+
+    &:hover {
+        border: 0.1rem solid white;
+    }
+`

--- a/frontend/src/containers/auth/genres.tsx
+++ b/frontend/src/containers/auth/genres.tsx
@@ -35,16 +35,6 @@ const genresDetails: GenreType[] = [
 export default function Genres({ handleGenresChange, handleFormSubmit }: GenresProps) {
 
     const [genres, setGenres] = useState<string[]>([])
-    const [loading, setLoading] = useState<boolean>(false)
-
-    const handleAuthSubmit = async () => {
-        if (loading || genres.length !== 2) {
-            return
-        }
-        setLoading(true)
-        await handleFormSubmit()
-        setLoading(false)
-    }
 
     useEffect(() => {
         handleGenresChange(genres)
@@ -83,8 +73,8 @@ export default function Genres({ handleGenresChange, handleFormSubmit }: GenresP
                     }
                     </AuthFormFields>
                     <AuthSubmit
-                        onClick={handleAuthSubmit}
-                        $loading={loading || genres.length !== 2}
+                        onClick={handleFormSubmit}
+                        $loading={genres.length !== 2}
                     >
                         <h3>Sign Up</h3>
                     </AuthSubmit>

--- a/frontend/src/containers/auth/signup.tsx
+++ b/frontend/src/containers/auth/signup.tsx
@@ -6,6 +6,7 @@ import { useGlobalContext } from "../../contexts/global.context"
 import { useNavigate } from "react-router"
 import { handleAPIError } from "../../utils/errors.util"
 import Genres from "./genres"
+import Artists from "./artists"
 
 export interface SignUpForm {
     username: string,
@@ -21,13 +22,15 @@ export default function SignUp() {
     const navigate = useNavigate()
 
     const [detailsEntered, setDetailsEntered] = useState<boolean>(false)
+    const [genres, setGenres] = useState<string[]>([])
+    const [genresEntered, setGenresEntered] = useState<boolean>(false)
 
     const [form, setForm] = useState<SignUpForm>({
         username: "",
         email: "",
         password: "",
         role: "common",
-        interests: []
+        interests: [],
     })
 
     const handleFormSubmit = async () => {
@@ -43,6 +46,11 @@ export default function SignUp() {
 
         if (!detailsEntered) {
             setDetailsEntered(true)
+            return
+        }
+
+        if (!genresEntered && genres.length == 2) {
+            setGenresEntered(true)
             return
         }
 
@@ -77,7 +85,11 @@ export default function SignUp() {
         })
     }
 
-    const handleGenresChange = (interests: string[]) => {
+    const handleGenresChange = (genres: string[]) => {
+        setGenres(genres)
+    }
+
+    const handleArtistsChange = (interests: string[]) => {
         setForm({
             ...form,
             interests: interests
@@ -107,6 +119,16 @@ export default function SignUp() {
             placeholder: "********"
         }
     ]
+
+    if (detailsEntered && genresEntered) {
+        return (
+            <Artists
+                handleArtistsChange={handleArtistsChange}
+                genres={genres}
+                handleFormSubmit={handleFormSubmit}
+            />
+        )
+    }
 
     if (detailsEntered) {
         return (


### PR DESCRIPTION
### Fixes/Implements #37 

## Description

- Introduced tags for albums, artists, songs and enable them in `Elasticsearch` indexes.
- Coded a script to taking in tags, for artists, albums and use the album's tags for songs.
- A new page is to introduced during sign-up, for the users to select their artists as a way of choosing different tags for other recommendations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested
