### PR TITLE
feat(backend): conditional playlist curation + tags

### DIFF
--- a/backend/api/endpoints/playlist.py
+++ b/backend/api/endpoints/playlist.py
@@ -7,7 +7,7 @@ from core.models.user import UserRole
 from core.models.playlist import Playlist
 from core.models.song import Song
 
-from core.schemas.playlist import Playlist as PlaylistSchema
+from core.schemas.playlist import Playlist as PlaylistSchema, PlaylistConditional
 from core.schemas.associations import SongPlaylistAssociation
 
 from core.utils.dependencies import get_db
@@ -52,6 +52,113 @@ async def create_playlist(
         es.index(index="playlists", id=new_playlist.id, body=playlist_document)
 
         return {"message": "Playlist Created Successfully!", "data": new_playlist}
+    except Exception as e:
+        raise handle_exception(e)
+
+
+@router.post(
+    "/create/conditional",
+    dependencies=[Depends(authenticate_common)],
+    status_code=status.HTTP_200_OK,
+)
+async def create_playlist_conditional(
+    request: Request, playlist: PlaylistConditional, db: Session = Depends(get_db)
+):
+    """
+    Creates a new playlist, adds songs to it based on the given conditions.
+    """
+
+    user = request.state.user
+
+    new_playlist = Playlist(title=playlist.title, user_id=user.id)
+
+    search_query = {"query": {"bool": {"must": []}}}
+
+    if playlist.genre and playlist.artists:
+        combined_query = {
+            "bool": {
+                "must": [
+                    {"terms": {"artist_id": playlist.artists}},
+                    {"terms": {"genre": playlist.genre}},
+                ]
+            }
+        }
+
+        search_query["query"]["bool"]["must"].append(combined_query)
+        search_query["size"] = playlist.num_songs if playlist.num_songs else 30
+        results = es.search(index="songs", body=search_query)
+        hits = results.get("hits", {}).get("hits", [])
+
+        if len(hits) < 5:
+
+            search_query["query"]["bool"]["must"] = []
+            search_query["query"]["bool"]["must"].append(
+                {"terms": {"genre": playlist.genre}}
+            )
+            results_genre = es.search(index="songs", body=search_query)
+            genres_hits = results_genre.get("hits", {}).get("hits", [])
+            hits.extend(genres_hits)
+
+            search_query["query"]["bool"]["must"] = []
+            search_query["query"]["bool"]["must"].append(
+                {"terms": {"artist_id": playlist.artists}}
+            )
+            results_artist = es.search(index="songs", body=search_query)
+            artist_hits = results_artist.get("hits", {}).get("hits", [])
+            hits.extend(artist_hits)
+
+    else:
+        if playlist.genre:
+            search_query["query"]["bool"]["must"].append(
+                {"terms": {"genre": playlist.genre}}
+            )
+        elif playlist.artists:
+            search_query["query"]["bool"]["must"].append(
+                {"terms": {"artist_id": playlist.artists}}
+            )
+
+        search_query["size"] = playlist.num_songs if playlist.num_songs else 30
+        results = es.search(index="songs", body=search_query)
+        hits = results.get("hits", {}).get("hits", [])
+
+    db.add(new_playlist)
+    db.commit()
+    db.refresh(new_playlist)
+
+    try:
+        for hit in hits:
+            song = db.query(Song).filter(Song.id == hit["_id"]).first()
+            new_playlist.songs.append(song)
+
+        db.commit()
+        db.refresh(new_playlist)
+
+        songs_data = [
+            {
+                "id": hit["_id"],
+                "title": hit["_source"].get("title", ""),
+                "artist_id": hit["_source"].get("artist_id", ""),
+                "album_id": hit["_source"].get("album_id", ""),
+                "artist_name": hit["_source"].get("artist_name", ""),
+                "album_title": hit["_source"].get("album_title", ""),
+                "genre": hit["_source"].get("genre", ""),
+                "length": hit["_source"].get("length", 0),
+                "tags": hit["_source"].get("tags", []),
+            }
+            for hit in hits
+        ]
+
+        playlist_document = {
+            "id": new_playlist.id,
+            "title": new_playlist.title,
+            "user_id": new_playlist.user_id,
+            "username": new_playlist.user.username,
+            "songs": songs_data,
+        }
+
+        es.index(index="playlists", id=new_playlist.id, body=playlist_document)
+
+        return {"message": "Playlist Created Successfully!", "data": playlist_document}
     except Exception as e:
         raise handle_exception(e)
 
@@ -206,16 +313,18 @@ async def add_song_to_playlist(
         db.commit()
         db.refresh(find_playlist)
 
+        find_song = es.get(index="songs", id=find_song.id).get("_source", {})
+
         song_document = {
-            "id": find_song.id,
-            "title": find_song.title,
-            "artist_id": find_song.artist_id,
-            "album_id": find_song.album_id,
-            "artist_name": find_song.artist.name,
-            "album_title": find_song.album.title,
-            "genre": find_song.genre,
-            "length": find_song.length,
-            "tags": find_song.tags,
+            "id": find_song.get("id", ""),
+            "title": find_song.get("title", ""),
+            "artist_id": find_song.get("artist_id", ""),
+            "album_id": find_song.get("album_id", ""),
+            "artist_name": find_song.get("artist_name", ""),
+            "album_title": find_song.get("album_title", ""),
+            "genre": find_song.get("genre", ""),
+            "length": find_song.get("length", 0),
+            "tags": find_song.get("tags", []),
         }
 
         es.update(

--- a/backend/core/schemas/playlist.py
+++ b/backend/core/schemas/playlist.py
@@ -1,6 +1,15 @@
 from pydantic import BaseModel, Field
+from typing import List, Optional
 
 
 class Playlist(BaseModel):
     title: str = Field(..., example="name")
     user_id: str = Field(..., example="1")
+
+
+class PlaylistConditional(BaseModel):
+    title: str = Field(..., example="name")
+    user_id: str = Field(..., example="1")
+    num_songs: Optional[int] = Field(None, example="10")
+    artists: List[str] = Field([], example="['shinee', 'bts']")
+    genre: Optional[List[str]] = Field(None, example="['pop']")


### PR DESCRIPTION
### Fixes/Implements #45 

## Description

- The back-end is accepting different user inputs - `num_songs`, `genres` or `artist`.
- Created dynamic queries on finding appropriate songs for the playlist, added the songs directly to `Postgres` and with tags to `ES`

## Type of change

Delete irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested
