### PR TITLE
fix(build): front-end now builds w/ styled-components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "@types/styled-components": "^5.1.34",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
### Fixes/Implements #50 

## Description

- The `styled-components` library was not typed according to the requirements.
- Hence, the build abruptly failed with errors, and is now fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Needs Testing From Production
